### PR TITLE
Different pool, different ConnectionManager

### DIFF
--- a/adafruit_connection_manager.py
+++ b/adafruit_connection_manager.py
@@ -289,12 +289,11 @@ class ConnectionManager:
 # global helpers
 
 
-_global_connection_manager = None  # pylint: disable=invalid-name
+_global_connection_manager = {}
 
 
-def get_connection_manager(socket_pool: SocketpoolModuleType) -> None:
-    """Get the ConnectionManager singleton"""
-    global _global_connection_manager  # pylint: disable=global-statement
-    if _global_connection_manager is None:
-        _global_connection_manager = ConnectionManager(socket_pool)
-    return _global_connection_manager
+def get_connection_manager(socket_pool: SocketpoolModuleType) -> ConnectionManager:
+    """Get the ConnectionManager singleton for the given pool"""
+    if socket_pool not in _global_connection_manager:
+        _global_connection_manager[socket_pool] = ConnectionManager(socket_pool)
+    return _global_connection_manager[socket_pool]

--- a/tests/get_connection_manager_test.py
+++ b/tests/get_connection_manager_test.py
@@ -16,3 +16,20 @@ def test_get_connection_manager():
     connection_manager_2 = adafruit_connection_manager.get_connection_manager(mock_pool)
 
     assert connection_manager_1 == connection_manager_2
+
+
+def test_different_connection_manager_different_pool():
+    radio_wifi = mocket.MockRadio.Radio()
+    radio_esp = mocket.MockRadio.ESP_SPIcontrol()
+
+    socket_pool_wifi = adafruit_connection_manager.get_radio_socketpool(radio_wifi)
+    socket_pool_esp = adafruit_connection_manager.get_radio_socketpool(radio_esp)
+
+    connection_manager_wifi = adafruit_connection_manager.get_connection_manager(
+        socket_pool_wifi
+    )
+    connection_manager_esp = adafruit_connection_manager.get_connection_manager(
+        socket_pool_esp
+    )
+
+    assert connection_manager_wifi != connection_manager_esp

--- a/tests/get_connection_manager_test.py
+++ b/tests/get_connection_manager_test.py
@@ -18,7 +18,9 @@ def test_get_connection_manager():
     assert connection_manager_1 == connection_manager_2
 
 
-def test_different_connection_manager_different_pool():
+def test_different_connection_manager_different_pool(  # pylint: disable=unused-argument
+    circuitpython_socketpool_module, adafruit_esp32spi_socket_module
+):
     radio_wifi = mocket.MockRadio.Radio()
     radio_esp = mocket.MockRadio.ESP_SPIcontrol()
 

--- a/tests/mocket.py
+++ b/tests/mocket.py
@@ -10,6 +10,13 @@ from unittest import mock
 MOCK_POOL_IP = "10.10.10.10"
 MOCK_HOST_1 = "wifitest.adafruit.com"
 MOCK_HOST_2 = "wifitest2.adafruit.com"
+MOCK_PATH_1 = "/testwifi/index.html"
+MOCK_ENDPOINT_1 = MOCK_HOST_1 + MOCK_PATH_1
+MOCK_ENDPOINT_2 = MOCK_HOST_2 + MOCK_PATH_1
+MOCK_RESPONSE_TEXT = (
+    b"This is a test of Adafruit WiFi!\r\nIf you can read this, its working :)"
+)
+MOCK_RESPONSE = b"HTTP/1.0 200 OK\r\nContent-Length: 70\r\n\r\n" + MOCK_RESPONSE_TEXT
 
 
 class MocketPool:  # pylint: disable=too-few-public-methods
@@ -27,7 +34,7 @@ class MocketPool:  # pylint: disable=too-few-public-methods
 class Mocket:  # pylint: disable=too-few-public-methods
     """Mock Socket"""
 
-    def __init__(self, response=None):
+    def __init__(self, response=MOCK_RESPONSE):
         self.settimeout = mock.Mock()
         self.close = mock.Mock()
         self.connect = mock.Mock()
@@ -35,14 +42,17 @@ class Mocket:  # pylint: disable=too-few-public-methods
         self.readline = mock.Mock(side_effect=self._readline)
         self.recv = mock.Mock(side_effect=self._recv)
         self.recv_into = mock.Mock(side_effect=self._recv_into)
+        # Test helpers
         self._response = response
         self._position = 0
         self.fail_next_send = False
+        self.sent_data = []
 
     def _send(self, data):
         if self.fail_next_send:
             self.fail_next_send = False
             return 0
+        self.sent_data.append(data)
         return len(data)
 
     def _readline(self):


### PR DESCRIPTION
Update ConnectionManager, to support multiple different pools at the same time.

Testing steps:
Have a device with onboard WiFi and either a ESP32SPI or WIZNET5K
Connect both and make requests on both and see that they are from different devices.

You can also use a WIZNET5K create it's request session first, and then disconnect it and verify the other device still works.