### PR TITLE
Support CPython

### DIFF
--- a/adafruit_connection_manager.py
+++ b/adafruit_connection_manager.py
@@ -97,6 +97,10 @@ def create_fake_ssl_context(
     return _FakeSSLContext(iface)
 
 
+class CPythonNetwork:  # pylint: disable=too-few-public-methods
+    """Radio object to use when using ConnectionManager in CPython."""
+
+
 _global_connection_managers = {}
 _global_key_by_socketpool = {}
 _global_socketpools = {}
@@ -157,6 +161,12 @@ def get_radio_socketpool(radio):
 
             if ssl_context is None:
                 ssl_context = create_fake_ssl_context(pool, radio)
+
+        elif class_name == "CPythonNetwork":
+            import socket as pool  # pylint: disable=import-outside-toplevel
+            import ssl  # pylint: disable=import-outside-toplevel
+
+            ssl_context = ssl.create_default_context()
 
         else:
             raise ValueError(f"Unsupported radio class: {class_name}")

--- a/tests/get_radio_test.py
+++ b/tests/get_radio_test.py
@@ -53,6 +53,13 @@ def test_get_radio_socketpool_wiznet5k(  # pylint: disable=unused-argument
     assert socket_pool in adafruit_connection_manager._global_socketpools.values()
 
 
+def test_get_radio_socketpool_cpython():
+    radio = adafruit_connection_manager.CPythonNetwork()
+    socket_pool = adafruit_connection_manager.get_radio_socketpool(radio)
+    assert socket_pool.__name__ == "socket"
+    assert socket_pool in adafruit_connection_manager._global_socketpools.values()
+
+
 def test_get_radio_socketpool_unsupported():
     radio = mocket.MockRadio.Unsupported()
     with pytest.raises(ValueError) as context:
@@ -95,6 +102,13 @@ def test_get_radio_ssl_context_wiznet5k(  # pylint: disable=unused-argument
     with mock.patch("sys.implementation", return_value=[9, 0, 0]):
         ssl_context = adafruit_connection_manager.get_radio_ssl_context(radio)
     assert isinstance(ssl_context, adafruit_connection_manager._FakeSSLContext)
+    assert ssl_context in adafruit_connection_manager._global_ssl_contexts.values()
+
+
+def test_get_radio_ssl_context_cpython():
+    radio = adafruit_connection_manager.CPythonNetwork()
+    ssl_context = adafruit_connection_manager.get_radio_ssl_context(radio)
+    assert isinstance(ssl_context, ssl.SSLContext)
     assert ssl_context in adafruit_connection_manager._global_ssl_contexts.values()
 
 


### PR DESCRIPTION
This allows you to use ConnectionManager in Cpython:
```
import adafruit_connection_manager

radio = adafruit_connection_manager.CPythonNetwork()
pool = adafruit_connection_manager.get_radio_socketpool(radio)
ssl_context = adafruit_connection_manager.get_radio_ssl_context(radio)
```
Allowing libraries to easily support CPython:
<img width="946" alt="image" src="https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager/assets/1547881/56417fa4-f568-4ef2-91a9-458f04f1b2ea">
